### PR TITLE
fix: node group prefix create too long name

### DIFF
--- a/modules/nodegroup/main.tf
+++ b/modules/nodegroup/main.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_node_group" "this" {
   cluster_name           = var.cluster_name
-  node_group_name_prefix = local.name
+  node_group_name        = format("%s-%s-nodegroup", local.prefix, var.name)
   node_role_arn          = var.node_role_arn
   subnet_ids             = var.subnet_ids
   instance_types         = var.instance_types


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:


### Fixes

- Node group prefix create the unique name that longer than 63 chars

## Why :pleading_face:

- Change back to node group name

