### PR TITLE
[FIX] Allow config user data when disable bootstrap command

### DIFF
--- a/modules/nodegroup/locals.tf
+++ b/modules/nodegroup/locals.tf
@@ -11,7 +11,6 @@ locals {
       cluster_endpoint    = var.cluster_endpoint
       cluster_auth_base64 = var.cluster_auth_base64
       # Optional
-      cluster_service_ipv4_cidr = var.cluster_service_ipv4_cidr != null ? var.cluster_service_ipv4_cidr : ""
       bootstrap_extra_args      = var.bootstrap_extra_args
       pre_bootstrap_user_data   = var.pre_bootstrap_user_data
       post_bootstrap_user_data  = var.post_bootstrap_user_data

--- a/modules/nodegroup/templates/linux_user_data.tpl
+++ b/modules/nodegroup/templates/linux_user_data.tpl
@@ -1,15 +1,11 @@
-%{ if enable_bootstrap_user_data ~}
 #!/bin/bash
 set -ex
-%{ endif ~}
 ${pre_bootstrap_user_data ~}
-%{ if length(cluster_service_ipv4_cidr) > 0 ~}
-export SERVICE_IPV4_CIDR=${cluster_service_ipv4_cidr}
-%{ endif ~}
-%{ if enable_bootstrap_user_data ~}
 
+%{ if enable_bootstrap_user_data ~}
 B64_CLUSTER_CA=${cluster_auth_base64}
 API_SERVER_URL=${cluster_endpoint}
 /etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL
-${post_bootstrap_user_data ~}
 %{ endif ~}
+
+${post_bootstrap_user_data ~}

--- a/modules/nodegroup/variables.tf
+++ b/modules/nodegroup/variables.tf
@@ -125,12 +125,6 @@ variable "cluster_auth_base64" {
   default     = ""
 }
 
-variable "cluster_service_ipv4_cidr" {
-  description = "The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks"
-  type        = string
-  default     = null
-}
-
 variable "pre_bootstrap_user_data" {
   description = "User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `platform` = `bottlerocket`"
   type        = string


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:
allow pre/post bootstrap when disable bootstrap command

### Adds

- None

### Fixes

- Allow to config user data when disable bootstrap command

### Changes

- launch template userdata

## Why :pleading_face:

- support config user data when disable bootstrap command

## Other Info

- None
